### PR TITLE
Update standard JS reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For that purpose create a REST API with the following endpoints:
 
 ## Requirements
 
-* Code must be written using `standardjs` convention
+* Code must be written using [`standard`](https://www.npmjs.com/package/standard) style convention
 
 * Code should run in `Node 8.10`
 


### PR DESCRIPTION
Some candidates seem to be confusing [`standard`](https://www.npmjs.com/package/standard)js with [`standardjs`](https://www.npmjs.com/package/standardjs). This should make it clearer to them which one we use, and also want them to use.

@pgahq/javascript 